### PR TITLE
Fix sunday showing as monday for region with monday-sunday calendar

### DIFF
--- a/CompactCalendar/Classes/CompactCalendarModel.swift
+++ b/CompactCalendar/Classes/CompactCalendarModel.swift
@@ -28,7 +28,10 @@ final class CompactCalendarModel: NSObject {
         /// The number of extra pages to generate in case the initial selected day is in the next 2-week chunk
         let extraPages = Int(extraDays) / 14
         let daysToPopulate = (extraPages + 2) * 14 // the number in (extraPages + 2) is how many pages you want generated at start
-        let weekday = Calendar.current.component(.weekday, from: today)
+        var weekday = Calendar.current.component(.weekday, from: today)
+        if weekday == 1 && weekStartsOnMonday() {
+            weekday = 8
+        }
 
         let firstWeekday = weekStartsOnMonday() ? 1 : 0
 


### PR DESCRIPTION
The problem was for region with calendar that's Monday-Sunday, when today is a Sunday, it shows as Monday on cal

## Changes
- changed what `weekday` is if it's a sunday and a monday-sunday calendar, in order for dates before today to be added corrected 

## Screenshot
**Before vs. After**
_Note: June 7 is a Sunday_ 

<img width="300" alt="Before" src="https://user-images.githubusercontent.com/48968041/83789031-240d1900-a664-11ea-9f8a-0a098d25bd4b.png">   <img width="300" alt="After" src="https://user-images.githubusercontent.com/48968041/83789035-27080980-a664-11ea-823e-300048548deb.png">


## Testing
For testing **Example**
- Change region on phone settings to somewhere with Mon-Sun cal (e.g. UK)
- Change date on laptop (if you're testing on simulator) to a sunday. 
- Calendar should show sunday correctly now
